### PR TITLE
Added a time warning for creating the results table

### DIFF
--- a/Database/SQL_add.m
+++ b/Database/SQL_add.m
@@ -615,7 +615,7 @@ fprintf(1,' Done.\n')
 if ~strcmp(addWhat,'mops')
     resultsTic = tic;
     if beVocal
-        fprintf(1,['Updating the Results table in %s\n(This could take a while, ' ...
+        fprintf(1,['Updating the Results table in %s\n(This could take a while (for 20,000 time series with all operations ~10hours), ' ...
                                 'please be patient)...'],databaseName)
     end
     switch addWhat


### PR DESCRIPTION
When running the code I was surprised by the ~10 hour wait for writing the results table. I thought it might be nice to tell people in advance. This 10 hour estimate is quite rough, I'm getting it from the total quoted time of the whole SQL_add operation of 20,000 time series with all 8263 operations.
