### PR TITLE
Adapted binarization so no 0.5 occurs

### DIFF
--- a/PeripheryFunctions/BF_Binarize.m
+++ b/PeripheryFunctions/BF_Binarize.m
@@ -38,21 +38,32 @@ if nargin < 2 || isempty(binarizeHow)
 end
 
 %-------------------------------------------------------------------------------
+% function to transform real values to 0 if <=0 and 1 if >0:
+%-------------------------------------------------------------------------------
+
+function Y = stepBinary(X)
+
+    Y = zeros(size(X),'like',X);
+    Y(X > 0) = 1;
+    
+end
+
+%-------------------------------------------------------------------------------
 % Do the binary transformation:
 %-------------------------------------------------------------------------------
 
 switch binarizeHow
     case 'diff'
         % Binary signal: 1 for stepwise increases, 0 for stepwise decreases
-        yBin = ((sign(diff(y)))+1)/2;
+        yBin = stepBinary(diff(y));
 
     case 'mean'
         % Binary signal: 1 for above mean, 0 for below mean
-        yBin = (sign(y - mean(y))+1)/2;
+        yBin = stepBinary(y - mean(y));
 
     case 'median'
         % Binary signal: 1 for above median, 0 for below median
-        yBin = (sign(y - median(y))+1)/2;
+        yBin = stepBinary(y - median(y));
 
     case 'iqr'
         % Binary signal: 1 if inside interquartile range, 0 otherwise


### PR DESCRIPTION
The current BF_Binarize.m function uses the sign function of Matlab to convert real numbers to 0s and 1s. But sign(0)=0. Therefore BF_Binarize sets the output to 0.5 where the transformed signal x (i.e. diff(x), x-mean(x), x-median(x)) is zero. Try e.g. BF_Binarize(0, 'mean') ... 0.5. I changed this so the output is actually only composed of 0s and 1s.