### PR TITLE
include gfortran in list of Fortran compilters

### DIFF
--- a/Toolboxes/Tisean_3.0.1/configure
+++ b/Toolboxes/Tisean_3.0.1/configure
@@ -1020,7 +1020,7 @@ fi
 
 
 
-for fff in "$FC" f77 g77 "f77 +U77" "f77 -q -f -B108 -lU77"; do
+for fff in "$FC" gfortran f77 g77 "f77 +U77" "f77 -q -f -B108 -lU77"; do
    if test -z "$fff"; then 
       continue
    fi


### PR DESCRIPTION
It seems g77 and f77 are not used anymore on most systems and were replaced by gfortran. Currently TISEAN asks the user during configuration to set an environment variable to point to the compiler if it doesn't find g77 or f77. But as gfortran is the standard and it really should check for this one. So I added it. 