### PR TITLE
minor correction on CO_f1ecac

### DIFF
--- a/Operations/CO_f1ecac.m
+++ b/Operations/CO_f1ecac.m
@@ -41,7 +41,7 @@ thresh = 1/exp(1); % 1/e threshold
 a = zeros(N,1); % autocorrelations
 a(1) = 1; % perfect autocorrelation when no lag
 for i = 2:N
-    a(i) = CO_AutoCorr(y,i,'Fourier');
+    a(i) = CO_AutoCorr(y,i-1,'Fourier');
     if ((a(i-1)-thresh)*(a(i)-thresh) < 0)
         % Crossed the 1/e line
         out = i-1; % -1 since i is tau+1


### PR DESCRIPTION
The lags in the original are 0,2,3,4,... leaving out the lag of 1. 

The code is also very inefficient because the Fourier-autocorrelation gives values for all lags at once but is still re-run for every single lag. In the attached file there is a shorter version but maybe you want to leave the autocorrelation function exchangeable.

[CO_f1ecac_m.txt](https://github.com/benfulcher/hctsa/files/2401581/CO_f1ecac_m.txt)

