### PR TITLE
Option to saturate rather than remove points

### DIFF
--- a/Operations/DN_RemovePoints.m
+++ b/Operations/DN_RemovePoints.m
@@ -66,6 +66,9 @@ end
 if nargin < 3 || isempty(p)
     p = 0.1; % 10%
 end
+if nargin < 4 || isempty(removeOrSaturate)
+    removeOrSaturate = 0;
+end
 
 % ------------------------------------------------------------------------------
 switch removeHow

--- a/Operations/DN_RemovePoints.m
+++ b/Operations/DN_RemovePoints.m
@@ -1,4 +1,4 @@
-function out = DN_RemovePoints(y,removeHow,p)
+function out = DN_RemovePoints(y,removeHow,p,removeOrSaturate)
 % DN_RemovePoints   How time-series properties change as points are removed.
 %
 % A proportion, p, of points are removed from the time series according to some
@@ -14,6 +14,8 @@ function out = DN_RemovePoints(y,removeHow,p)
 %               (v) 'random': at random.
 %
 % p, the proportion of points to remove
+%
+% removeOrSaturate, to remove points (false) or saturate their values (true)
 %
 %---OUTPUTS: Statistics include the change in autocorrelation, time scales, mean,
 % spread, and skewness.
@@ -83,6 +85,14 @@ end
 
 rKeep = sort(is(1:round(N*(1-p))),'ascend');
 y_trim = y(rKeep);
+
+if removeOrSaturate
+    if any(strcmp(removeHow, {'random', 'absclose'}))
+        error('Cannot saturate when using ''%s'' method', removeHow)
+    else
+        y_trim = min(max(y, min(y_trim)), max(y_trim));
+    end
+end
 
 if doPlot
     figure('color','w')


### PR DESCRIPTION
An extra argument 'removeOrSaturate' controls whether points are removed completely (and the left-overs concatenated) or their values are saturated (replaced with a threshold value).

I haven't added saturation for the 'random' (that wouldn't make sense?) or 'absclose' (maybe to the nearest threshold?) remove methods, but I can if there's a way you'd like those to work.

Also, the 'ac1' features in DN_RemovePoints look like they might be using acf(0) (so 'ac1rat' always gives 1, and 'ac1diff' 0); if that's an issue then maybe on the fifth last line (in 'SUB_acf'):
`acf(i) = CO_AutoCorr(x,i-1,'Fourier');`
could be:\
`acf(i) = CO_AutoCorr(x,i,'Fourier');`

<br>
Brendan
<br>
<br>
<br>
<br>
<br>
<br>

### E.g.
`DN_RemovePoints(x, 'absfar', 0.4, 1)`
![image](https://user-images.githubusercontent.com/42064608/63919900-ff579580-ca82-11e9-9052-5bdad93b597d.jpeg)
