### PR TITLE
Small Edits

### DIFF
--- a/Calculation/TS_Combine.m
+++ b/Calculation/TS_Combine.m
@@ -204,7 +204,7 @@ if merge_features
     numTimeSeries = numTimeSeries(1); % both the same
 
     % Check that all TimeSeries names match:
-    namesMatch = (loadedData{1}.TimeSeries.Name == loadedData{2}.TimeSeries.Name);
+    namesMatch = strcmp(loadedData{1}.TimeSeries.Name, loadedData{2}.TimeSeries.Name);
     if ~all(namesMatch)
         error('The names of time series in the two files do not match');
     end

--- a/Calculation/TS_Compute.m
+++ b/Calculation/TS_Compute.m
@@ -191,7 +191,7 @@ for i = 1:numTimeSeries
 	        [featureVector,calcTimes,calcQuality] = TS_CalculateFeatureVector(TimeSeries(tsInd,:),...
 								doParallel,Operations(toCalc,:),MasterOperations,true,beVocal);
 		catch
-			skip to the next time series; the entries for this time series in TS_DataMat etc. will remain NaNs
+			% skip to the next time series; the entries for this time series in TS_DataMat etc. will remain NaNs
 			warning('Calculation for time series %u / %u failed...',i,numTimeSeries)
 			continue
 		end

--- a/Calculation/TS_Init.m
+++ b/Calculation/TS_Init.m
@@ -140,7 +140,7 @@ gitInfo = TS_AddGitInfo();
 % TS_init and shouldn't be written back to a database
 fromDatabase = false;
 save(outputFile,'TimeSeries','Operations','MasterOperations',...
-            'TS_DataMat','TS_Quality','TS_CalcTime','fromDatabase','gitInfo');
+            'TS_DataMat','TS_Quality','TS_CalcTime','fromDatabase','gitInfo','-v7.3');
 
 fprintf(1,'Successfully initialized %s with %u time series, %u master operations, and %u operations\n',...
                         outputFile,numTS,numMops,numOps);


### PR DESCRIPTION
- A line of TS_Compute.m was missing a comment

- A '-v7.3' flag might be useful to save data in TS_Init(), for large time series datasets and to be consistent with saves in e.g. TS_Normalize.m

- In TS_Combine.m, if using `merge_features` the comparison between time series names gives an error; fixed by strcmp().
