### PR TITLE
Free yWork at early returns

### DIFF
--- a/Toolboxes/catch22/C/DN_OutlierInclude.c
+++ b/Toolboxes/catch22/C/DN_OutlierInclude.c
@@ -40,13 +40,17 @@ double DN_OutlierInclude_np_001_mdrmd(const double y[], const int size, const in
         }
         
     }
-    if(constantFlag) return 0; // if constant, return 0
+    if(constantFlag){
+        free(yWork);
+        return 0; // if constant, return 0
+    }
     
     // find maximum (or minimum, depending on sign)
     double maxVal = max_(yWork, size);
     
     // maximum value too small? return 0
     if(maxVal < inc){
+        free(yWork);
         return 0;
     }
     


### PR DESCRIPTION
In the catch22 toolbox DN_OutlierInclude.c in DN_OutlierInclude_np_001_mdrmd function line 43 and line 50, if the early return conditions were met then yWork doesn't get free() 'd. Simple free statements 