### PR TITLE
Fixed Parallel Computing Toolbox typo

### DIFF
--- a/PeripheryFunctions/BF_CheckToolbox.m
+++ b/PeripheryFunctions/BF_CheckToolbox.m
@@ -71,7 +71,7 @@ case 'financial_toolbox'
     theName = 'Financial Toolbox';
 case 'database_toolbox'
     theName = 'Database Toolbox';
-case 'parallel_computing_toolbox'
+case 'distrib_computing_toolbox'
     theName = 'Parallel Computing Toolbox';
 otherwise
     error('Unknown toolbox ''%s''.\n',theToolbox);


### PR DESCRIPTION
This fixes the typo mentioned in #76 - `BF_CheckToolBox` searches for `parallel_computing_toolbox` while it is actually called `distrib_computing_toolbox`. 