### PR TITLE
Update name for distrib_computing_toolbox

### DIFF
--- a/PeripheryFunctions/BF_CheckToolbox.m
+++ b/PeripheryFunctions/BF_CheckToolbox.m
@@ -71,7 +71,7 @@ case 'financial_toolbox'
     theName = 'Financial Toolbox';
 case 'database_toolbox'
     theName = 'Database Toolbox';
-case 'parallel_computing_toolbox'
+case 'distrib_computing_toolbox'
     theName = 'Parallel Computing Toolbox';
 otherwise
     error('Unknown toolbox ''%s''.\n',theToolbox);

--- a/PeripheryFunctions/TS_InitiateParallel.m
+++ b/PeripheryFunctions/TS_InitiateParallel.m
@@ -37,7 +37,7 @@ end
 
 % Check a license is available:
 try
-    BF_CheckToolbox('parallel_computing_toolbox')
+    BF_CheckToolbox('distrib_computing_toolbox')
 catch
     fprintf(1,['License for Parallel Computing Toolbox could not be initiated' ...
                 ' -- cannot perform computations across multiple cores.\n']);

--- a/install.m
+++ b/install.m
@@ -71,7 +71,7 @@ if noStatToolbox
     fprintf(1,'The Statistics and Machine Learning Toolbox is required for hctsa and needs to be installed.\n');
 end
 % For distributed computing
-noDistributedToolbox = BF_CheckToolbox('parallel_computing_toolbox',true,true);
+noDistributedToolbox = BF_CheckToolbox('distrib_computing_toolbox',true,true);
 if noDistributedToolbox
     fprintf(1,'Matlab''s Parallel Computing Toolbox is required for distributed calculation but is not installed.\n');
 end


### PR DESCRIPTION
More recent Matlab versions have renamed the tag for the Parallel Computing Toolbox from 'parallel_computing_toolbox' to 'distrib_computing_toolbox'. This PR renames the toolbox string accordingly in the toolbox checks so that parallel processing can be run.