### PR TITLE
Optimize calculation of 2-sample mean in MF_steps_ahead

### DIFF
--- a/Operations/MF_steps_ahead.m
+++ b/Operations/MF_steps_ahead.m
@@ -165,15 +165,8 @@ for i = 1:maxSteps
 
     % (3) *** Sliding mean 2 ***
     % A sliding mean of length 2
-    sm2p = zeros(N-i-1,1);
-    for j = 1:N-i-1
-        seeds = yy(j:j+1);
-        for k = 1:i % average with itself this many times
-            p = mean(seeds);
-            seeds = [seeds(2),p];
-        end
-        sm2p(j) = p;
-    end
+    weights = [1 + (-1)^(i+1)/2^i; 2 + (-1)^i/2^i] ./ 3;
+    sm2p = [yy(1:N-i-1), yy(2:N-i)] * weights;
     mres = yy(i+2:end) - sm2p;
 
     sm2.rmserrs(i) = sqrt(mean(mres.^2));


### PR DESCRIPTION
This PR optimises the calculation of the 2-sample mean in the `MF_steps_ahead` operation. 

```matlab
% A sliding mean of length 2
sm2p = zeros(N-i-1,1);
for j = 1:N-i-1
    seeds = yy(j:j+1);
    for k = 1:i % average with itself this many times
        p = mean(seeds);
        seeds = [seeds(2),p];
    end
    sm2p(j) = p;
end
```
Mathematically reframed, the code above iteratively calculates the terms of the following sequence (p subscript is for predict):

Let $y_j$ and $y_{j+1}$ be 2 consecutive samples of $y$.

$$y_\mathrm{p}(0) = y_j, y_\mathrm{p}(1) = y_{j+1},$$

$$\forall n\geq 2,\ y_\mathrm{p} (n) = \frac{y_\mathrm{p} (n-1) + y_\mathrm{p} (n-2)}{2},$$

which gives the value of the 2-sample mean predictor at $j+n$. This is a linear recurrence relation of order 2. It admits a closed-form expression that you can work out (see e.g. [Wikipedia article](https://en.wikipedia.org/wiki/Linear_recurrence_with_constant_coefficients#Solution_example_for_small_orders)).

$$\forall i\geq 1,\ y_p (i) = \frac{1}{3}\left(1+\frac{(-1)^{i+1}}{2^i}\right)y_j +\frac{2}{3}\left(1+\frac{(-1)^{i}}{2^{i+1}}\right)y_{j+1}$$

Note that I did a change of variable so that $i$ is the prediction length. Under this form, the "weights" used in the 2-sample mean can be computed directly regardless of the prediction length. This also implies that it is no longer needed to iterate "manually" over the samples of the time series using a for loop. The code above can then be rewritten as a simple matrix product:
```matlab
% A sliding mean of length 2
weights = [1 + (-1)^(i+1)/2^i; 2 + (-1)^i/2^i] ./ 3;
sm2p = [yy(1:N-i-1), yy(2:N-i)] * weights;
```
This piece of code runs between tens to thousands of times faster on my laptop, depending on the length of the time series and the prediction length. 
<img width="500" height="400" alt="pr-hctsa-speedup" src="https://github.com/user-attachments/assets/5563824c-aedc-4d7c-8c8a-d1c0f8b3c8d8" />
